### PR TITLE
Refactored to reflect new project directory structure

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -3,8 +3,11 @@
 - name: Setup eg-customer environment
   hosts: "{{host_inventory}}"
   vars_files:
-    - vars/global.yml
-    - dn-kafka/vars/deployment-settings.yml
+    - dn-kafka/vars/kafka.yml
+    - vars/cloud.yml
+    - vars/tenant.yml
+    - vars/test-project.yml
+    - vars/development-domain.yml
   vars:
     - combined_package_list: "{{ (default_packages|default([])) | union(kafka_package_list) | union((install_packages_by_tag|default({})).kafka|default([])) }}"
   roles:

--- a/vars/cloud.yml
+++ b/vars/cloud.yml
@@ -1,0 +1,6 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+#
+# Variables that are used for all deployments
+# (split apart by cloud type: 'aws', 'openstack', etc.)
+---
+cloud: vagrant

--- a/vars/development-domain.yml
+++ b/vars/development-domain.yml
@@ -1,0 +1,6 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+#
+# Variables that are used for all deployments within
+# a given domain ('production', 'test', 'development', etc.)
+---
+domain: development

--- a/vars/dn-solr.yml
+++ b/vars/dn-solr.yml
@@ -1,6 +1,0 @@
-# (c) 2016 DataNexus Inc.  All Rights Reserved
----
-# solr_url: "https://download.lucidworks.com/fusion-2.4.4.tar.gz",
-solr_url: "https://10.0.2.2/fusion-2.4.4.tar.gz"
-solr_addr: 192.168.34.12
-solr_dir: "/opt/fusion"

--- a/vars/tenant.yml
+++ b/vars/tenant.yml
@@ -1,4 +1,7 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved
+#
+# Variables that are used for all deployments in a tenant
+# environment (proxies, extra packages per node, etc.)
 ---
 # proxy-related variables (values are retrieved from the corresponding
 # environment variables, if they are set)

--- a/vars/test-project.yml
+++ b/vars/test-project.yml
@@ -1,0 +1,13 @@
+# (c) 2016 DataNexus Inc.  All Rights Reserved
+#
+# Variables that are used for all deployments in given
+# project (project-greenfield, customer-demo, etc.)
+---
+scala_version: 2.11
+kafka_version: 0.10.1.0
+kafka_distro: apache
+kafka_url: "https://10.0.2.2/dist/kafka/{{kafka_version}}/kafka_{{scala_version}}-{{kafka_version}}.tgz"
+kafka_dir: "/opt/kafka"
+# confluent_version: "3.1"
+kafka_iface: eth1
+kafka_topics: ["metrics", "logs"]


### PR DESCRIPTION
The changes in this pull request refactor this repository to bring it in line with the way we'll be creating all of our project repositories; specifically:
* it defines a new heirarchy for the files in the `vars` directory that are used to define the parameters used when deploying one or more applications to a customer environment; that hierarchy is as follows:
  * `{{application}}/vars/{{application}}.yml`:  the file from a given submodule that contains the defaults for deploying a the application in that submodule; there can be one or more of these included in the `site.yml` file for each play)
  * `vars/cloud.yml`:  the file used to define the parameters that are common across a given cloud (`aws`, `openstack`, etc.)
  * `vars/tenant.yml`: the file used to define the parameters that are common across a given tenant
  * `vars`/{{project}}-project.yml:  the file used to define parameters that are common across a given project
  * `vars`/{{domain}}-domain.yml:  the file used to define parameters that are common across a given domain (eg. `test`, `development`, `productiion`)

Any values defined in files later in this hierarchy will override values defined earlier, so it is quite easy to redefine values in the tenant or project level to override the defaults specified at the application level (for example, in this `eg-customer` repository we override the Kafka deployment so that it deploys the `apache`, rather than the default `confluent`, distribution of Kakfa and it instructs Kafka to listen on the `eth1` interface instead of the default `eth0` interface).